### PR TITLE
DEV-741: Stopped `DefaultAnswer` from throwing `NullPointerException` for types that have not been supplied that can return `null`.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,20 +1,27 @@
 # Test Utils JVM changelog
+
 ## [2.1.0] - UNRELEASED
+
 ### Breaking Changes
+
 * None.
 
 ### New Features
+
 * None.
 
 ### Enhancements
+
 * None.
 
 ### Fixes
-* None.
+
+* Stopped `DefaultAnswer` from throwing `NullPointerException` for types that have not been supplied that can
+  return `null`.
 
 ### Notes
-* None.
 
+* None.
 
 ## [2.0.0] - 2024-02-21
 

--- a/src/main/java/com/zepben/testutils/mockito/DefaultAnswer.kt
+++ b/src/main/java/com/zepben/testutils/mockito/DefaultAnswer.kt
@@ -18,7 +18,7 @@ class DefaultAnswer private constructor(
     private val answers: MutableMap<Class<*>, Any> = HashMap()
 
     @Throws(Throwable::class)
-    override fun answer(invocation: InvocationOnMock): Any =
+    override fun answer(invocation: InvocationOnMock): Any? =
         answers[invocation.method.returnType] ?: defaultAnswer.answer(invocation)
 
     inline fun <reified T> and(answer: Any): DefaultAnswer =

--- a/src/test/java/com/zepben/testutils/mockito/DefaultAnswerTest.kt
+++ b/src/test/java/com/zepben/testutils/mockito/DefaultAnswerTest.kt
@@ -57,6 +57,18 @@ class DefaultAnswerTest {
         }
     }
 
+    @Test
+    internal fun `allows nullable default answers`() {
+        // This test is in place because the original Kotlin implementation threw a NullPointerException when the
+        // underlying default answers returned null.
+
+        // Create a default answer replacing something we are not using so our calls use the underlying default answer.
+        mock<TestObject>(DefaultAnswer.of<Double>(0.0)).apply {
+            assertThat(nullableFunc(), nullValue())
+        }
+    }
+
+
     private fun validateMock(
         testObject: TestObject,
         intMatcher: Matcher<Any>,

--- a/src/test/java/com/zepben/testutils/mockito/TestObject.java
+++ b/src/test/java/com/zepben/testutils/mockito/TestObject.java
@@ -9,6 +9,7 @@
 package com.zepben.testutils.mockito;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.util.List;
 
 //
@@ -33,5 +34,8 @@ interface TestObject {
 
     @Nonnull
     List<Integer> integerListFunc2();
+
+    @Nullable
+    TestObject nullableFunc();
 
 }


### PR DESCRIPTION
# Description

Fixes the bug that made `DefaultAnswer` throw a `NullPointerException` for types that have not been supplied that return `null`.

# Checklist

If any of these are not applicable, strikethrough the line `~like this~`. **Do not delete it!**. Let the reviewer decide if you should have done it.

### Code
- [x] I have performed a self review of my own code (including checking issues raised when creating the PR).
- [x] I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.
- [x] I have commented my code in any hard-to-understand or hacky areas.
- [x] I have handled all new warnings generated by the compiler or IDE.
- [x] I have rebased onto the target branch (usually main).
      
### Documentation
- [x] I have updated the changelog.
~- [ ] I have updated any documentation required for these changes.~

# Breaking Changes
- [x] I have considered if this is a breaking change and will communicate it with other team members if so.

No breaking changes