### PR TITLE
EDNAR-1455 Implement a better solution for SystemLogExtension

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,13 +1,13 @@
 # Test Utils JVM changelog
-## [2.2.0] - UNRELEASED
+## [3.0.0] - UNRELEASED
 ### Breaking Changes
-* None.
+* In Kotlin, SystemLogExtension needs to be instantiated inside the companion objects of a test class.
 
 ### New Features
 * None.
 
 ### Enhancements
-* None.
+* SystemLogExtension now correctly mutes all output, even output of objects constructed within a test class but outside a test, if told to do so.
 
 ### Fixes
 * None.

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
 
     <groupId>com.zepben</groupId>
     <artifactId>test-utils</artifactId>
-    <version>2.2.0b1</version>
+    <version>3.0.0b1</version>
     <packaging>jar</packaging>
     <name>${project.groupId}:${project.artifactId}</name>
     <description>Helpers and utils for writing unit tests in various zepben projects.</description>
@@ -49,6 +49,12 @@
         <developer>
             <name>Kurt Greaves</name>
             <email>kurt.greaves@zepben.com</email>
+            <organization>Zeppelin Bend</organization>
+            <organizationUrl>https://zepben.com</organizationUrl>
+        </developer>
+        <developer>
+            <name>Ramon Bouckaert</name>
+            <email>ramon.bouckaert@zepben.com</email>
             <organization>Zeppelin Bend</organization>
             <organizationUrl>https://zepben.com</organizationUrl>
         </developer>

--- a/src/main/kotlin/com/zepben/testutils/junit/SystemLogExtension.kt
+++ b/src/main/kotlin/com/zepben/testutils/junit/SystemLogExtension.kt
@@ -81,12 +81,10 @@ class SystemLogExtension private constructor(
         initialSettings = logWrapper.settings
     }
 
-    @Throws(Exception::class)
     override fun beforeEach(extensionContext: ExtensionContext) {
         logWrapper.settings = initialSettings
     }
 
-    @Throws(Exception::class)
     override fun afterEach(extensionContext: ExtensionContext) {
         if (extensionContext.executionException.isPresent) logWrapper.failureLog.writeTo(originalStream)
 

--- a/src/test/kotlin/com/zepben/testutils/junit/SystemLogExtensionTest.kt
+++ b/src/test/kotlin/com/zepben/testutils/junit/SystemLogExtensionTest.kt
@@ -8,6 +8,7 @@
 package com.zepben.testutils.junit
 
 import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.contains
 import org.hamcrest.Matchers.equalTo
 import org.hamcrest.Matchers.not
 import org.junit.jupiter.api.Test
@@ -15,13 +16,18 @@ import org.junit.jupiter.api.extension.RegisterExtension
 
 internal class SystemLogExtensionTest {
 
-    @JvmField
-    @RegisterExtension
-    var systemOut = SystemLogExtension.SYSTEM_OUT.captureLog().muteOnSuccess()
+    companion object {
+        @JvmField
+        @RegisterExtension
+        var systemOut = SystemLogExtension.SYSTEM_OUT.captureLog().muteOnSuccess()
 
-    @JvmField
-    @RegisterExtension
-    var systemErr = SystemLogExtension.SYSTEM_ERR.captureLog().muteOnSuccess()
+        @JvmField
+        @RegisterExtension
+        var systemErr = SystemLogExtension.SYSTEM_ERR.captureLog().muteOnSuccess()
+    }
+
+    // This is simulating a pattern where initialising a class property inside a test class would itself create log lines
+    private val classLevelLogMessage = "Example of a string produced while constructing the test class".also { println(it) }
 
     @Test
     fun capturesLogsAndMutes() {
@@ -40,8 +46,10 @@ internal class SystemLogExtensionTest {
         System.err.println("err line 1")
         System.err.println("err line 2")
 
-        assertThat(systemOut.logLines.size, equalTo(3))
+        assertThat(systemOut.logLines.size, equalTo(4)) // Three out lines, plus the example constructor string
         assertThat(systemErr.logLines.size, equalTo(2))
+
+        assertThat(systemOut.logLines.toList(), contains(classLevelLogMessage, "out line 1", "out line 2", "out line 3"))
 
         assertThat(systemOut.clearCapturedLog().logLines.size, equalTo(0))
         assertThat(systemErr.clearCapturedLog().logLines.size, equalTo(0))


### PR DESCRIPTION
# Description

`SystemLogExtension` is used for managing stdout and stderr for tests using JUnit5. In most cases, it is used to mute the output of successful tests, so they don't utterly overwhelm the build logs.

However, it fails to mute stdout/stderr caused by the construction of objects used as properties _outside_ a test method but _inside_ a test suite class. In reality, we do this all the time, so we don't actually end up cleaning our build logs.

This PR modifies `SystemLogExtension` to replace the output stream both on initalisation and in the `beforeAll` override for tests. If this is done at the top of the companion object of a test (for Kotlin) or at the top of the class (for Java), this will mute stdout/stderr for subsequent object instatiations in that test class.

We also do some cleanup after, and introduce `LogWrapperSettings` to better internally manage the state of the log wrapper.

# Associated tasks

Part of bigger EDNAR test cleanup. No link.

# Checklist

If any of these are not applicable, strikethrough the line `~like this~`. **Do not delete it!**. Let the reviewer decide if you should have done it.

### Code
- [x] I have performed a self review of my own code (including checking issues raised when creating the PR).
- [x] I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.
- [x] I have commented my code in any hard-to-understand or hacky areas.
- [x] I have handled all new warnings generated by the compiler or IDE.
- [x] I have rebased onto the target branch (usually main).

### Security
When developing applications, use following guidelines for information security considerations:
* Access to applications should be protected with security keys/tokens or usernames and passwords;
* All sessions are encrypted if possible;
* All application input is sanitised before being acted on (ie SQL statements, etc);
* Log messages, and especially client-facing ones, must be handled securely and must not leak credentials information (internal URLs, passwords, tokens).

- [x] I have considered if this change impacts information security and made sure those impacts are handled.

No security impact.

### Documentation
- [x] I have updated the changelog.
- [x] I have updated any documentation required for these changes.

# Breaking Changes
- [x] I have considered if this is a breaking change and will communicate it with other team members by posting it on the Slack **breaking-changes** channel.

Yes! This introduces a breaking change when using the `SystemLogExtension` in Kotlin. It now needs to be wrapped in a companion object to be used.
