### PR TITLE
[DEV-8616] Added `TestClassValidator`

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -4,6 +4,11 @@
       <option name="DO_NOT_WRAP_AFTER_SINGLE_ANNOTATION" value="true" />
     </JavaCodeStyleSettings>
     <JetCodeStyleSettings>
+      <option name="ALLOW_TRAILING_COMMA" value="true" />
+      <option name="ALLOW_TRAILING_COMMA_COLLECTION_LITERAL_EXPRESSION" value="true" />
+      <option name="ALLOW_TRAILING_COMMA_TYPE_ARGUMENT_LIST" value="true" />
+      <option name="ALLOW_TRAILING_COMMA_INDICES" value="true" />
+      <option name="ALLOW_TRAILING_COMMA_VALUE_ARGUMENT_LIST" value="true" />
       <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
     </JetCodeStyleSettings>
     <Markdown>

--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -2,6 +2,6 @@
 <project version="4">
   <component name="KotlinJpsPluginSettings">
     <option name="externalSystemId" value="Maven" />
-    <option name="version" value="1.9.24" />
+    <option name="version" value="2.3.20" />
   </component>
 </project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -8,5 +8,5 @@
       </list>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" project-jdk-name="11" project-jdk-type="JavaSDK" />
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" project-jdk-name="17" project-jdk-type="JavaSDK" />
 </project>

--- a/changelog.md
+++ b/changelog.md
@@ -4,7 +4,8 @@
 * None.
 
 ### New Features
-* None.
+* Added `TestClassValidator`, which should be used by all repos to validate their tests are configured correctly by
+  creating a test and calling `TestClassValidator.validate`.
 
 ### Enhancements
 * None.
@@ -56,7 +57,8 @@
 * None.
 
 ### Enhancements
-* SystemLogExtension now correctly mutes all output, even output of objects constructed within a test class but outside a test, if told to do so.
+* SystemLogExtension now correctly mutes all output, even output of objects constructed within a test class but outside
+  a test, if told to do so.
 
 ### Fixes
 * None.

--- a/src/main/kotlin/com/zepben/testutils/junit/TestClassValidator.kt
+++ b/src/main/kotlin/com/zepben/testutils/junit/TestClassValidator.kt
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) Zeppelin Bend Pty Ltd (Zepben) 2026 - All Rights Reserved.
+ * Unauthorized use, copy, or distribution of this file or its contents, via any medium is strictly prohibited.
+ */
+
+package com.zepben.testutils.junit
+
+import com.google.common.reflect.ClassPath
+import org.hamcrest.MatcherAssert.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
+import java.lang.reflect.Field
+import java.lang.reflect.Method
+import java.lang.reflect.Modifier
+
+/**
+ * Validation methods to run against your test classes.
+ */
+object TestClassValidator {
+
+    /**
+     * Validates your test classes are:
+     * * Using the correct `Test` annotation from JUnit5.
+     * * Using one of the log suppression extensions, and only one if [allowMultiLogExtensions] is `false`.
+     * * The log suppression extensions are:
+     *     * Registered as an extension.
+     *     * Defined as static.
+     *     * Defined as final/val.
+     *     * Named `systemOut` or `systemErr` respectably.
+     *
+     * @param packageName Optional pacakge name to use as the root for testing. Defaults to "com.zepben".
+     * @param allowMultiLogExtensions Optional flag to allow both SYSTEM_ERR and SYSTEM_OUT to be used together.
+     * Defaults to `false`, which is the expected value when using Logback with a test config that moves all messages
+     * to the same appender.
+     *
+     * @throws AssertionError If test classes are detected that breach the rules.
+     */
+    fun validate(
+        packageName: String = "com.zepben",
+        excludingPackages: Set<String> = emptySet(),
+        allowMultiLogExtensions: Boolean = false,
+    ) {
+        val testClassDetails =
+            ClassPath.from(ClassLoader.getSystemClassLoader()).allClasses
+                .asSequence()
+                .filter { it.name.startsWith(packageName) }
+                .filterNot { excludingPackages.any { exclude -> it.name.startsWith(exclude) } }
+                .filter { it.isProjectClass() }
+                .mapNotNull { runCatching { ClassDetails(it.load()) }.getOrNull() }
+                .filter { it.testMethods.isNotEmpty() }
+                .toList()
+
+        val incorrectTestAnnotation = testClassDetails.filter { details ->
+            details.testMethods.filterNot { it.isAnnotationPresent(Test::class.java) }.isNotEmpty()
+        }
+
+        val unregisteredSystemLogExtensions = testClassDetails.filter { details ->
+            details.systemLogExtensions.filterNot { it.isAnnotationPresent(RegisterExtension::class.java) }.isNotEmpty()
+        }
+
+        val missingSystemLogExtension = testClassDetails.filter { details ->
+            details.systemLogExtensions.isEmpty()
+        }
+
+        val extraSystemLogExtension = if (allowMultiLogExtensions) emptyList() else testClassDetails.filter { details ->
+            details.systemLogExtensions.size > 1
+        }
+
+        val nonStaticSystemLogExtension = testClassDetails.filter { details ->
+            details.systemLogExtensions.filterNot { Modifier.isStatic(it.modifiers) }.isNotEmpty()
+        }
+
+        val nonFinalSystemLogExtension = testClassDetails.filter { details ->
+            details.systemLogExtensions.filterNot { Modifier.isFinal(it.modifiers) }.isNotEmpty()
+        }
+
+        val systemLogExtensionByType =
+            testClassDetails.flatMap { details -> details.systemLogExtensions.map { details to it } }
+                .filter { (_, field) -> Modifier.isStatic(field.modifiers) }
+                .groupBy { (_, field) ->
+                    field.trySetAccessible()
+                    field.get(null)
+                }
+
+        val incorrectSystemLogExtensionNames = systemLogExtensionByType.flatMap { (type, detailsToField) ->
+            when (type) {
+                SystemLogExtension.SYSTEM_OUT -> detailsToField.filter { (_, field) -> field.name != "systemOut" }
+                SystemLogExtension.SYSTEM_ERR -> detailsToField.filter { (_, field) -> field.name != "systemErr" }
+                else -> throw NotImplementedError("Unsupported SystemLogExtension $type")
+            }
+        }
+
+        var reason = """
+                Malformed test classes detected:
+
+                Tests with incorrect `Test` annotations: $incorrectTestAnnotation,
+                Tests with unregistered `SystemLogExtension`: $unregisteredSystemLogExtensions,
+                Tests with missing `SystemLogExtension`: $missingSystemLogExtension,
+                Tests with extra `SystemLogExtension`: $extraSystemLogExtension,
+                Tests with non-static `SystemLogExtension`: $nonStaticSystemLogExtension,
+                Tests with non-final `SystemLogExtension`: $nonFinalSystemLogExtension,
+                Tests with incorrectly named `SystemLogExtension` variables: ${incorrectSystemLogExtensionNames.formatted},
+            """.trimIndent()
+        if (!allowMultiLogExtensions)
+            reason += "\n\nShould all be using the same `SystemLogExtension` type: ${systemLogExtensionByType.formatted}"
+
+        assertThat(
+            reason,
+            incorrectTestAnnotation.isEmpty() &&
+                unregisteredSystemLogExtensions.isEmpty() &&
+                missingSystemLogExtension.isEmpty() &&
+                extraSystemLogExtension.isEmpty() &&
+                nonStaticSystemLogExtension.isEmpty() &&
+                nonFinalSystemLogExtension.isEmpty() &&
+                (allowMultiLogExtensions || (systemLogExtensionByType.size == 1)) &&
+                (incorrectSystemLogExtensionNames.isEmpty()),
+        )
+    }
+
+    private val List<Pair<ClassDetails, Field>>.formatted: List<String> get() = map { (details, field) -> "${details.clazz.simpleName}.${field.name}" }
+    private val Map<Any, List<Pair<ClassDetails, Field>>>.formatted: Map<String, Int>
+        get() =
+            mapKeys { (systemLogExtension, _) ->
+                when (systemLogExtension) {
+                    SystemLogExtension.SYSTEM_OUT -> "SystemLogExtension.SYSTEM_OUT"
+                    else /*SystemLogExtension.SYSTEM_ERR*/ -> "SystemLogExtension.SYSTEM_ERR"
+                }
+            }.mapValues { (_, values) -> values.size }
+
+    private class ClassDetails(
+        val clazz: Class<*>,
+    ) {
+
+        val testMethods: List<Method> by lazy {
+            clazz.declaredMethods.filter { method ->
+                method.annotations.any { it.annotationClass.simpleName == "Test" }
+            }
+        }
+
+        val systemLogExtensions: List<Field> by lazy {
+            clazz.declaredFields.filter { field -> field.type == SystemLogExtension::class.java }
+        }
+
+        override fun toString(): String = clazz.canonicalName.removePrefix(clazz.packageName).removePrefix(".")
+
+    }
+
+    // Get the actual URL of the class file. If this is anything other than "file" it means it has been pulled in
+    // from outside the project. i.e. via a jar.
+    private fun ClassPath.ClassInfo.isProjectClass(): Boolean =
+        Thread.currentThread().getContextClassLoader().getResource(resourceName)?.protocol == "file"
+
+}

--- a/src/main/kotlin/com/zepben/testutils/junit/TestClassValidator.kt
+++ b/src/main/kotlin/com/zepben/testutils/junit/TestClassValidator.kt
@@ -1,6 +1,9 @@
 /*
- * Copyright (c) Zeppelin Bend Pty Ltd (Zepben) 2026 - All Rights Reserved.
- * Unauthorized use, copy, or distribution of this file or its contents, via any medium is strictly prohibited.
+ * Copyright 2026 Zeppelin Bend Pty Ltd
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
 package com.zepben.testutils.junit

--- a/src/test/kotlin/com/zepben/testutils/RandomTest.kt
+++ b/src/test/kotlin/com/zepben/testutils/RandomTest.kt
@@ -7,18 +7,26 @@
  */
 package com.zepben.testutils
 
+import com.zepben.testutils.junit.SystemLogExtension
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.*
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
 
 class RandomTest {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val systemOut: SystemLogExtension = SystemLogExtension.SYSTEM_OUT.captureLog().muteOnSuccess()
+    }
 
     @Test
     fun coverage() {
         assertThat(Random.ofEnum(TestEnum::class.java), any(TestEnum::class.java))
         assertThat(
             Random.ofEnum(TestEnum::class.java),
-            anyOf(equalTo(TestEnum.A), equalTo(TestEnum.B), equalTo(TestEnum.C))
+            anyOf(equalTo(TestEnum.A), equalTo(TestEnum.B), equalTo(TestEnum.C)),
         )
 
         assertThat(Random.ofEnum<TestEnum>(), any(TestEnum::class.java))

--- a/src/test/kotlin/com/zepben/testutils/auth/AuthUtilsTest.kt
+++ b/src/test/kotlin/com/zepben/testutils/auth/AuthUtilsTest.kt
@@ -8,13 +8,21 @@
 
 package com.zepben.testutils.auth
 
+import com.zepben.testutils.junit.SystemLogExtension
 import io.grpc.Metadata
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
 import org.hamcrest.Matchers.nullValue
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
 
 class AuthUtilsTest {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val systemOut: SystemLogExtension = SystemLogExtension.SYSTEM_OUT.captureLog().muteOnSuccess()
+    }
 
     @Test
     fun testMockServerCall() {
@@ -44,4 +52,5 @@ class AuthUtilsTest {
         assertThat(mm.stream(0), nullValue())
         assertThat(mm.parse(null), nullValue())
     }
+
 }

--- a/src/test/kotlin/com/zepben/testutils/exception/ExpectExceptionKotlinTest.kt
+++ b/src/test/kotlin/com/zepben/testutils/exception/ExpectExceptionKotlinTest.kt
@@ -8,14 +8,23 @@
 package com.zepben.testutils.exception
 
 import com.zepben.testutils.exception.ExpectException.Companion.expect
+import com.zepben.testutils.junit.SystemLogExtension
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
 import java.io.IOException
 import java.security.InvalidKeyException
 import java.util.regex.Pattern
 
 class ExpectExceptionKotlinTest {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val systemOut: SystemLogExtension = SystemLogExtension.SYSTEM_OUT.captureLog().muteOnSuccess()
+    }
+
     @Test
     fun catchesAny() {
         expect { funcThatThrows() }.toThrowAny()
@@ -193,4 +202,5 @@ class ExpectExceptionKotlinTest {
     private fun funcThatThrowsBlank() {
         throw IOException("")
     }
+
 }

--- a/src/test/kotlin/com/zepben/testutils/exception/ExpectExceptionTest.kt
+++ b/src/test/kotlin/com/zepben/testutils/exception/ExpectExceptionTest.kt
@@ -9,14 +9,22 @@ package com.zepben.testutils.exception
 
 import com.zepben.testutils.exception.ExpectException.Companion.expect
 import com.zepben.testutils.exception.ExpectExceptionError.Companion.formatForJunit
+import com.zepben.testutils.junit.SystemLogExtension
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.sameInstance
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
 import java.io.IOException
 import java.security.InvalidKeyException
 import java.util.regex.Pattern
 
 class ExpectExceptionTest {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val systemOut: SystemLogExtension = SystemLogExtension.SYSTEM_OUT.captureLog().muteOnSuccess()
+    }
 
     @Test
     fun catchesAny() {

--- a/src/test/kotlin/com/zepben/testutils/hamcrest/InputStreamMatcherTest.kt
+++ b/src/test/kotlin/com/zepben/testutils/hamcrest/InputStreamMatcherTest.kt
@@ -8,17 +8,24 @@
 package com.zepben.testutils.hamcrest
 
 import com.zepben.testutils.hamcrest.InputStreamMatcher.Companion.matchesContent
+import com.zepben.testutils.junit.SystemLogExtension
 import org.hamcrest.Description
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
 import org.junit.jupiter.api.Test
-import org.mockito.ArgumentMatchers
+import org.junit.jupiter.api.extension.RegisterExtension
 import org.mockito.Mockito.*
 import java.io.ByteArrayInputStream
 import java.io.InputStream
 import java.nio.charset.StandardCharsets
 
 class InputStreamMatcherTest {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val systemOut: SystemLogExtension = SystemLogExtension.SYSTEM_OUT.captureLog().muteOnSuccess()
+    }
 
     private val matcher1 = matchesContent("matches one")
     private val matcher2 = matchesContent("matches two")
@@ -41,10 +48,10 @@ class InputStreamMatcherTest {
 
         matcher1.describeTo(description)
 
-        verify(description, times(1)).appendText(ArgumentMatchers.any())
+        verify(description, times(1)).appendText(any())
         verify(description, times(1)).appendText("InputStream containing ")
 
-        verify(description, times(1)).appendValue(ArgumentMatchers.any())
+        verify(description, times(1)).appendValue(any())
         verify(description, times(1)).appendValue("matches one")
     }
 
@@ -54,10 +61,10 @@ class InputStreamMatcherTest {
 
         matcher1.describeMismatchSafely(inputStreamOf("other stream"), description)
 
-        verify(description, times(1)).appendText(ArgumentMatchers.any())
+        verify(description, times(1)).appendText(any())
         verify(description, times(1)).appendText(" was ")
 
-        verify(description, times(1)).appendValue(ArgumentMatchers.any())
+        verify(description, times(1)).appendValue(any())
         verify(description, times(1)).appendValue("other stream")
     }
 

--- a/src/test/kotlin/com/zepben/testutils/junit/SystemLogExtensionTest.kt
+++ b/src/test/kotlin/com/zepben/testutils/junit/SystemLogExtensionTest.kt
@@ -8,9 +8,7 @@
 package com.zepben.testutils.junit
 
 import org.hamcrest.MatcherAssert.assertThat
-import org.hamcrest.Matchers.contains
-import org.hamcrest.Matchers.equalTo
-import org.hamcrest.Matchers.not
+import org.hamcrest.Matchers.*
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.RegisterExtension
 
@@ -19,11 +17,23 @@ internal class SystemLogExtensionTest {
     companion object {
         @JvmField
         @RegisterExtension
-        var systemOut = SystemLogExtension.SYSTEM_OUT.captureLog().muteOnSuccess()
+        val systemOut = SystemLogExtension.SYSTEM_OUT.captureLog().muteOnSuccess()
 
         @JvmField
         @RegisterExtension
-        var systemErr = SystemLogExtension.SYSTEM_ERR.captureLog().muteOnSuccess()
+        val systemErr = SystemLogExtension.SYSTEM_ERR.captureLog().muteOnSuccess()
+
+        //
+        // NOTE: You can also log a static message here, but it won't work how you expect when running all the tests.
+        //       It will work correctly if you run `capturesLogsAndMutes` as a single test, but it can be swallowed
+        //       elsewhere when running all tests, resulting in a test failure. You'll just have to trust it is working,
+        //       which can be verified by adding the following block, adding it as the first expected message in
+        //       `capturesLogsAndMutes` (commented out below), then running that test individually:
+        //
+        //       // This is simulating a pattern where initialising a static property inside a test class would itself create log lines
+        //       private val staticLevelLogMessage =
+        //          "Example of a string produced statically before constructing the test class".also { println(it) }
+        //
     }
 
     // This is simulating a pattern where initialising a class property inside a test class would itself create log lines
@@ -46,10 +56,17 @@ internal class SystemLogExtensionTest {
         System.err.println("err line 1")
         System.err.println("err line 2")
 
+        // Swap if using staticLevelLogMessage above:
+        // assertThat(systemOut.logLines.size, equalTo(5)) // Three out lines, plus the example static and constructor strings
         assertThat(systemOut.logLines.size, equalTo(4)) // Three out lines, plus the example constructor string
         assertThat(systemErr.logLines.size, equalTo(2))
 
-        assertThat(systemOut.logLines.toList(), contains(classLevelLogMessage, "out line 1", "out line 2", "out line 3"))
+        assertThat(
+            systemOut.logLines.toList(),
+            // Swap if using staticLevelLogMessage above:
+            // contains(staticLevelLogMessage, classLevelLogMessage, "out line 1", "out line 2", "out line 3"),
+            contains(classLevelLogMessage, "out line 1", "out line 2", "out line 3"),
+        )
 
         assertThat(systemOut.clearCapturedLog().logLines.size, equalTo(0))
         assertThat(systemErr.clearCapturedLog().logLines.size, equalTo(0))

--- a/src/test/kotlin/com/zepben/testutils/junit/TestClassValidatorTest.kt
+++ b/src/test/kotlin/com/zepben/testutils/junit/TestClassValidatorTest.kt
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2026 Zeppelin Bend Pty Ltd
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package com.zepben.testutils.junit
+
+import com.zepben.testutils.exception.ExpectException.Companion.expect
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
+
+class TestClassValidatorTest {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val systemOut: SystemLogExtension = SystemLogExtension.SYSTEM_OUT.captureLog().muteOnSuccess()
+    }
+
+    //
+    // NOTE: The expected number of extensions detected in the `data` classes designed for testing. You might expect
+    //       4 and 8, but they are only captured for classes with valid `@Test` methods, so we miss the incorrect
+    //       annotation, and outer class of the non-static test.
+    //
+    private val expectedSystemErrInData = 3
+    private val expectedSystemOutInData = 6
+
+    @Test
+    internal fun `detects all the things we are worried about`() {
+        //
+        // NOTE: The `WithNonStaticLogExtensionTest` uses `WithNonStaticLogExtensionTest.Inner` because it needed to be
+        //       `@Nested` to avoid potential for `lateinit` errors when using the `SystemLogExtension` in a non-static
+        //       context.
+        //
+        expect {
+            TestClassValidator.validate(packageName = "com.zepben.testutils.junit.data")
+        }.toThrow<AssertionError>()
+            .withMessage(
+                """
+                    Malformed test classes detected:
+
+                    Tests with incorrect `Test` annotations: [WithInvalidTestAnnotationTest],
+                    Tests with unregistered `SystemLogExtension`: [WithUnregisteredLogExtensionTest],
+                    Tests with missing `SystemLogExtension`: [WithoutLogExtensionTest],
+                    Tests with extra `SystemLogExtension`: [WithMultipleLogExtensionTest],
+                    Tests with non-static `SystemLogExtension`: [WithNonStaticLogExtensionTest.Inner],
+                    Tests with non-final `SystemLogExtension`: [WithNonFinalLogExtensionTest],
+                    Tests with incorrectly named `SystemLogExtension` variables: [WithIncorrectlyNamedErrLogExtensionTest.systemErrRule, WithIncorrectlyNamedOutLogExtensionTest.systemOutRule],
+
+                    Should all be using the same `SystemLogExtension` type: {SystemLogExtension.SYSTEM_ERR=${expectedSystemErrInData}, SystemLogExtension.SYSTEM_OUT=${expectedSystemOutInData}}
+                """.trimIndent(),
+            )
+    }
+
+    @Test
+    internal fun `only reports multiple log extensions when it isn't allowed`() {
+        expect {
+            TestClassValidator.validate(packageName = "com.zepben.testutils.junit.data", allowMultiLogExtensions = true)
+        }.toThrow<AssertionError>()
+            .withMessage(
+                """
+                    Malformed test classes detected:
+
+                    Tests with incorrect `Test` annotations: [WithInvalidTestAnnotationTest],
+                    Tests with unregistered `SystemLogExtension`: [WithUnregisteredLogExtensionTest],
+                    Tests with missing `SystemLogExtension`: [WithoutLogExtensionTest],
+                    Tests with extra `SystemLogExtension`: [],
+                    Tests with non-static `SystemLogExtension`: [WithNonStaticLogExtensionTest.Inner],
+                    Tests with non-final `SystemLogExtension`: [WithNonFinalLogExtensionTest],
+                    Tests with incorrectly named `SystemLogExtension` variables: [WithIncorrectlyNamedErrLogExtensionTest.systemErrRule, WithIncorrectlyNamedOutLogExtensionTest.systemOutRule],
+                """.trimIndent(),
+            )
+    }
+
+    @Test
+    internal fun `validate test classes`() {
+        //
+        // NOTE: When validating all our JUnit test classes we still expect our deliberately corrupted tests to fail,
+        //       plus the `SystemLogExtensionTest` which uses both extensions to validate they are capturing properly.
+        //
+        //       There should be an extra use of `SystemLogExtension.SYSTEM_ERR` in `SystemLogExtensionTest`, plus
+        //       another use of `SystemLogExtension.SYSTEM_OUT` in `SystemLogExtensionTest` and this class.
+        //
+        TestClassValidator.validate("com.zepben", excludingPackages = setOf("com.zepben.testutils.junit"))
+
+        expect {
+            TestClassValidator.validate("com.zepben.testutils.junit")
+        }.toThrow<AssertionError>()
+            .withMessage(
+                """
+                    Malformed test classes detected:
+
+                    Tests with incorrect `Test` annotations: [WithInvalidTestAnnotationTest],
+                    Tests with unregistered `SystemLogExtension`: [WithUnregisteredLogExtensionTest],
+                    Tests with missing `SystemLogExtension`: [WithoutLogExtensionTest],
+                    Tests with extra `SystemLogExtension`: [WithMultipleLogExtensionTest, SystemLogExtensionTest],
+                    Tests with non-static `SystemLogExtension`: [WithNonStaticLogExtensionTest.Inner],
+                    Tests with non-final `SystemLogExtension`: [WithNonFinalLogExtensionTest],
+                    Tests with incorrectly named `SystemLogExtension` variables: [WithIncorrectlyNamedErrLogExtensionTest.systemErrRule, WithIncorrectlyNamedOutLogExtensionTest.systemOutRule],
+
+                    Should all be using the same `SystemLogExtension` type: {SystemLogExtension.SYSTEM_ERR=${expectedSystemErrInData + 1}, SystemLogExtension.SYSTEM_OUT=${expectedSystemOutInData + 2}}
+                """.trimIndent(),
+            )
+    }
+
+}

--- a/src/test/kotlin/com/zepben/testutils/junit/TestClassValidatorTest.kt
+++ b/src/test/kotlin/com/zepben/testutils/junit/TestClassValidatorTest.kt
@@ -11,6 +11,7 @@ package com.zepben.testutils.junit
 import com.zepben.testutils.exception.ExpectException.Companion.expect
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.RegisterExtension
+import java.util.regex.Pattern
 
 class TestClassValidatorTest {
 
@@ -39,19 +40,26 @@ class TestClassValidatorTest {
             TestClassValidator.validate(packageName = "com.zepben.testutils.junit.data")
         }.toThrow<AssertionError>()
             .withMessage(
-                """
-                    Malformed test classes detected:
+                //
+                // NOTE: We use regex to allow the order to change on different systems depending on how they load
+                //       the classes. If the load order changes, so do the order of the list/map elements. This was
+                //       first noticed as a difference between a Windows system and CI (Linux).
+                //
+                Pattern.compile(
+                    """
+                        Malformed test classes detected:
 
-                    Tests with incorrect `Test` annotations: [WithInvalidTestAnnotationTest],
-                    Tests with unregistered `SystemLogExtension`: [WithUnregisteredLogExtensionTest],
-                    Tests with missing `SystemLogExtension`: [WithoutLogExtensionTest],
-                    Tests with extra `SystemLogExtension`: [WithMultipleLogExtensionTest],
-                    Tests with non-static `SystemLogExtension`: [WithNonStaticLogExtensionTest.Inner],
-                    Tests with non-final `SystemLogExtension`: [WithNonFinalLogExtensionTest],
-                    Tests with incorrectly named `SystemLogExtension` variables: [WithIncorrectlyNamedErrLogExtensionTest.systemErrRule, WithIncorrectlyNamedOutLogExtensionTest.systemOutRule],
+                        Tests with incorrect `Test` annotations: \[WithInvalidTestAnnotationTest],
+                        Tests with unregistered `SystemLogExtension`: \[WithUnregisteredLogExtensionTest],
+                        Tests with missing `SystemLogExtension`: \[WithoutLogExtensionTest],
+                        Tests with extra `SystemLogExtension`: \[WithMultipleLogExtensionTest],
+                        Tests with non-static `SystemLogExtension`: \[WithNonStaticLogExtensionTest.Inner],
+                        Tests with non-final `SystemLogExtension`: \[WithNonFinalLogExtensionTest],
+                        Tests with incorrectly named `SystemLogExtension` variables: \[(WithIncorrectlyNamedErrLogExtensionTest.systemErrRule, WithIncorrectlyNamedOutLogExtensionTest.systemOutRule|WithIncorrectlyNamedOutLogExtensionTest.systemOutRule, WithIncorrectlyNamedErrLogExtensionTest.systemErrRule)],
 
-                    Should all be using the same `SystemLogExtension` type: {SystemLogExtension.SYSTEM_ERR=${expectedSystemErrInData}, SystemLogExtension.SYSTEM_OUT=${expectedSystemOutInData}}
-                """.trimIndent(),
+                        Should all be using the same `SystemLogExtension` type: \{(SystemLogExtension.SYSTEM_ERR=${expectedSystemErrInData}, SystemLogExtension.SYSTEM_OUT=${expectedSystemOutInData}|SystemLogExtension.SYSTEM_OUT=${expectedSystemOutInData}, SystemLogExtension.SYSTEM_ERR=${expectedSystemErrInData})}
+                    """.trimIndent(),
+                ),
             )
     }
 
@@ -90,19 +98,26 @@ class TestClassValidatorTest {
             TestClassValidator.validate("com.zepben.testutils.junit")
         }.toThrow<AssertionError>()
             .withMessage(
-                """
-                    Malformed test classes detected:
+                //
+                // NOTE: We use regex to allow the order to change on different systems depending on how they load
+                //       the classes. If the load order changes, so do the order of the list/map elements. This was
+                //       first noticed as a difference between a Windows system and CI (Linux).
+                //
+                Pattern.compile(
+                    """
+                        Malformed test classes detected:
 
-                    Tests with incorrect `Test` annotations: [WithInvalidTestAnnotationTest],
-                    Tests with unregistered `SystemLogExtension`: [WithUnregisteredLogExtensionTest],
-                    Tests with missing `SystemLogExtension`: [WithoutLogExtensionTest],
-                    Tests with extra `SystemLogExtension`: [WithMultipleLogExtensionTest, SystemLogExtensionTest],
-                    Tests with non-static `SystemLogExtension`: [WithNonStaticLogExtensionTest.Inner],
-                    Tests with non-final `SystemLogExtension`: [WithNonFinalLogExtensionTest],
-                    Tests with incorrectly named `SystemLogExtension` variables: [WithIncorrectlyNamedErrLogExtensionTest.systemErrRule, WithIncorrectlyNamedOutLogExtensionTest.systemOutRule],
+                        Tests with incorrect `Test` annotations: \[WithInvalidTestAnnotationTest],
+                        Tests with unregistered `SystemLogExtension`: \[WithUnregisteredLogExtensionTest],
+                        Tests with missing `SystemLogExtension`: \[WithoutLogExtensionTest],
+                        Tests with extra `SystemLogExtension`: \[(WithMultipleLogExtensionTest, SystemLogExtensionTest|SystemLogExtensionTest, WithMultipleLogExtensionTest)],
+                        Tests with non-static `SystemLogExtension`: \[WithNonStaticLogExtensionTest.Inner],
+                        Tests with non-final `SystemLogExtension`: \[WithNonFinalLogExtensionTest],
+                        Tests with incorrectly named `SystemLogExtension` variables: \[(WithIncorrectlyNamedErrLogExtensionTest.systemErrRule, WithIncorrectlyNamedOutLogExtensionTest.systemOutRule|WithIncorrectlyNamedOutLogExtensionTest.systemOutRule, WithIncorrectlyNamedErrLogExtensionTest.systemErrRule)],
 
-                    Should all be using the same `SystemLogExtension` type: {SystemLogExtension.SYSTEM_ERR=${expectedSystemErrInData + 1}, SystemLogExtension.SYSTEM_OUT=${expectedSystemOutInData + 2}}
-                """.trimIndent(),
+                        Should all be using the same `SystemLogExtension` type: \{(SystemLogExtension.SYSTEM_ERR=${expectedSystemErrInData + 1}, SystemLogExtension.SYSTEM_OUT=${expectedSystemOutInData + 2}|SystemLogExtension.SYSTEM_OUT=${expectedSystemOutInData + 2}, SystemLogExtension.SYSTEM_ERR=${expectedSystemErrInData + 1})}
+                    """.trimIndent(),
+                ),
             )
     }
 

--- a/src/test/kotlin/com/zepben/testutils/junit/data/WithIncorrectlyNamedErrLogExtensionTest.kt
+++ b/src/test/kotlin/com/zepben/testutils/junit/data/WithIncorrectlyNamedErrLogExtensionTest.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2026 Zeppelin Bend Pty Ltd
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package com.zepben.testutils.junit.data
+
+import com.zepben.testutils.junit.SystemLogExtension
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
+
+// Used via the class loader in `TestClassValidator`.
+@Suppress("unused")
+internal class WithIncorrectlyNamedErrLogExtensionTest {
+
+    companion object {
+        // NOTE: Deliberately misnamed for testing purposes.
+        @JvmField
+        @RegisterExtension
+        val systemErrRule: SystemLogExtension = SystemLogExtension.SYSTEM_ERR.captureLog().muteOnSuccess()
+    }
+
+    @Test
+    internal fun `mark as test class`() {
+    }
+
+}

--- a/src/test/kotlin/com/zepben/testutils/junit/data/WithIncorrectlyNamedOutLogExtensionTest.kt
+++ b/src/test/kotlin/com/zepben/testutils/junit/data/WithIncorrectlyNamedOutLogExtensionTest.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2026 Zeppelin Bend Pty Ltd
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package com.zepben.testutils.junit.data
+
+import com.zepben.testutils.junit.SystemLogExtension
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
+
+// Used via the class loader in `TestClassValidator`.
+@Suppress("unused")
+internal class WithIncorrectlyNamedOutLogExtensionTest {
+
+    companion object {
+        // NOTE: Deliberately misnamed for testing purposes.
+        @JvmField
+        @RegisterExtension
+        val systemOutRule: SystemLogExtension = SystemLogExtension.SYSTEM_OUT.captureLog().muteOnSuccess()
+    }
+
+    @Test
+    internal fun `mark as test class`() {
+    }
+
+}

--- a/src/test/kotlin/com/zepben/testutils/junit/data/WithInvalidTestAnnotationTest.kt
+++ b/src/test/kotlin/com/zepben/testutils/junit/data/WithInvalidTestAnnotationTest.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2026 Zeppelin Bend Pty Ltd
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package com.zepben.testutils.junit.data
+
+import com.zepben.testutils.junit.SystemLogExtension
+import org.junit.jupiter.api.extension.RegisterExtension
+
+annotation class Test
+
+// Used via the class loader in `TestClassValidator`.
+@Suppress("unused")
+internal class WithInvalidTestAnnotationTest {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val systemOut: SystemLogExtension = SystemLogExtension.SYSTEM_OUT.captureLog().muteOnSuccess()
+    }
+
+    // NOTE: Deliberately not JUnit5 for testing purposes.
+    @Test
+    internal fun `mark as test class`() {
+    }
+
+}

--- a/src/test/kotlin/com/zepben/testutils/junit/data/WithMultipleLogExtensionTest.kt
+++ b/src/test/kotlin/com/zepben/testutils/junit/data/WithMultipleLogExtensionTest.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2026 Zeppelin Bend Pty Ltd
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package com.zepben.testutils.junit.data
+
+import com.zepben.testutils.junit.SystemLogExtension
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
+
+// Used via the class loader in `TestClassValidator`.
+@Suppress("unused")
+internal class WithMultipleLogExtensionTest {
+
+    // NOTE: Deliberately using both extensions for testing purposes.
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val systemOut: SystemLogExtension = SystemLogExtension.SYSTEM_OUT.captureLog().muteOnSuccess()
+
+        @JvmField
+        @RegisterExtension
+        val systemErr: SystemLogExtension = SystemLogExtension.SYSTEM_ERR.captureLog().muteOnSuccess()
+    }
+
+    @Test
+    internal fun `mark as test class`() {
+    }
+
+}

--- a/src/test/kotlin/com/zepben/testutils/junit/data/WithNonFinalLogExtensionTest.kt
+++ b/src/test/kotlin/com/zepben/testutils/junit/data/WithNonFinalLogExtensionTest.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2026 Zeppelin Bend Pty Ltd
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package com.zepben.testutils.junit.data
+
+import com.zepben.testutils.junit.SystemLogExtension
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
+
+// Used via the class loader in `TestClassValidator`.
+@Suppress("unused")
+internal class WithNonFinalLogExtensionTest {
+
+    companion object {
+        // NOTE: Deliberately non-final for testing purposes.
+        @JvmField
+        @RegisterExtension
+        var systemOut: SystemLogExtension = SystemLogExtension.SYSTEM_OUT.captureLog().muteOnSuccess()
+    }
+
+    @Test
+    internal fun `mark as test class`() {
+    }
+
+}

--- a/src/test/kotlin/com/zepben/testutils/junit/data/WithNonStaticLogExtensionTest.kt
+++ b/src/test/kotlin/com/zepben/testutils/junit/data/WithNonStaticLogExtensionTest.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2026 Zeppelin Bend Pty Ltd
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package com.zepben.testutils.junit.data
+
+import com.zepben.testutils.junit.SystemLogExtension
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
+
+// Used via the class loader in `TestClassValidator`.
+@Suppress("unused")
+internal class WithNonStaticLogExtensionTest {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val systemOut: SystemLogExtension = SystemLogExtension.SYSTEM_OUT.captureLog().muteOnSuccess()
+    }
+
+    /**
+     * NOTE: We mark this as an inner/nested test to ensure we have at least one static copy of the log extension. If
+     *       we didn't do this, we run the risk of this being the first test run and failing the lateinit property
+     *       check in the extension.
+     */
+    @Nested
+    inner class Inner {
+
+        // NOTE: Deliberately non-static for testing purposes.
+        @JvmField
+        @RegisterExtension
+        @Suppress("JUnitMalformedDeclaration")
+        val systemOut: SystemLogExtension = SystemLogExtension.SYSTEM_OUT.captureLog().muteOnSuccess()
+
+        @Test
+        internal fun `mark as test class`() {
+        }
+    }
+
+}

--- a/src/test/kotlin/com/zepben/testutils/junit/data/WithSystemErrLogExtensionTest.kt
+++ b/src/test/kotlin/com/zepben/testutils/junit/data/WithSystemErrLogExtensionTest.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2026 Zeppelin Bend Pty Ltd
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package com.zepben.testutils.junit.data
+
+import com.zepben.testutils.junit.SystemLogExtension
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
+
+// Used via the class loader in `TestClassValidator`.
+@Suppress("unused")
+internal class WithSystemErrLogExtensionTest {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val systemErr: SystemLogExtension = SystemLogExtension.SYSTEM_ERR.captureLog().muteOnSuccess()
+    }
+
+    @Test
+    internal fun `mark as test class`() {
+    }
+
+}

--- a/src/test/kotlin/com/zepben/testutils/junit/data/WithSystemOutLogExtensionTest.kt
+++ b/src/test/kotlin/com/zepben/testutils/junit/data/WithSystemOutLogExtensionTest.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2026 Zeppelin Bend Pty Ltd
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package com.zepben.testutils.junit.data
+
+import com.zepben.testutils.junit.SystemLogExtension
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
+
+// Used via the class loader in `TestClassValidator`.
+@Suppress("unused")
+internal class WithSystemOutLogExtensionTest {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val systemOut: SystemLogExtension = SystemLogExtension.SYSTEM_OUT.captureLog().muteOnSuccess()
+    }
+
+    @Test
+    internal fun `mark as test class`() {
+    }
+
+}

--- a/src/test/kotlin/com/zepben/testutils/junit/data/WithUnregisteredLogExtensionTest.kt
+++ b/src/test/kotlin/com/zepben/testutils/junit/data/WithUnregisteredLogExtensionTest.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2026 Zeppelin Bend Pty Ltd
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package com.zepben.testutils.junit.data
+
+import com.zepben.testutils.junit.SystemLogExtension
+import org.junit.jupiter.api.Test
+
+// Used via the class loader in `TestClassValidator`.
+@Suppress("unused")
+internal class WithUnregisteredLogExtensionTest {
+
+    companion object {
+        // NOTE: Deliberately unregistered for testing purposes.
+        @Suppress("unused")
+        val systemOut: SystemLogExtension = SystemLogExtension.SYSTEM_OUT.captureLog().muteOnSuccess()
+    }
+
+    @Test
+    internal fun `mark as test class`() {
+    }
+
+}

--- a/src/test/kotlin/com/zepben/testutils/junit/data/WithoutLogExtensionTest.kt
+++ b/src/test/kotlin/com/zepben/testutils/junit/data/WithoutLogExtensionTest.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2026 Zeppelin Bend Pty Ltd
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package com.zepben.testutils.junit.data
+
+import org.junit.jupiter.api.Test
+
+// Used via the class loader in `TestClassValidator`.
+@Suppress("unused")
+internal class WithoutLogExtensionTest {
+
+    // NOTE: Deliberately missing extensions for testing purposes.
+
+    @Test
+    internal fun `mark as test class`() {
+    }
+
+}

--- a/src/test/kotlin/com/zepben/testutils/mockito/DefaultAnswerTest.kt
+++ b/src/test/kotlin/com/zepben/testutils/mockito/DefaultAnswerTest.kt
@@ -7,13 +7,21 @@
  */
 package com.zepben.testutils.mockito
 
+import com.zepben.testutils.junit.SystemLogExtension
 import org.hamcrest.Matcher
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.*
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
 import org.mockito.Mockito.mock
 
 class DefaultAnswerTest {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val systemOut: SystemLogExtension = SystemLogExtension.SYSTEM_OUT.captureLog().muteOnSuccess()
+    }
 
     @Test
     fun changesDefaultAnswers() {
@@ -51,7 +59,7 @@ class DefaultAnswerTest {
         // Should only provide defaults for both primitive and boxed ints.
         mock(
             TestObject::class.java,
-            DefaultAnswer.of(Int::class.javaPrimitiveType!!, 100).and(Int::class.javaObjectType, 200)
+            DefaultAnswer.of(Int::class.javaPrimitiveType!!, 100).and(Int::class.javaObjectType, 200),
         ).also {
             validateMock(it, equalTo(100), equalTo(200))
         }
@@ -73,7 +81,7 @@ class DefaultAnswerTest {
         testObject: TestObject,
         intMatcher: Matcher<Any>,
         integerMatcher: Matcher<Any>,
-        vararg listValues: Int
+        vararg listValues: Int,
     ) {
         assertThat(testObject.intFunc1(), intMatcher)
         assertThat(testObject.intFunc2(), intMatcher)


### PR DESCRIPTION
# Description

Added `TestClassValidator`, which should be used by all repos to validate their tests are configured correctly by creating a test and calling `TestClassValidator.validate`.

# Test Steps

It is the tester of tests.

# Checklist

If any of these are not applicable, strikethrough the line `~like this~`. **Do not delete it!**. Let the reviewer decide if you should have done it.

### Code
- [x] I have performed a self review of my own code (including checking issues raised when creating the PR).
- [x] I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.
- [x] I have commented my code in any hard-to-understand or hacky areas.
- [x] I have handled all new warnings generated by the compiler or IDE.
- [x] I have rebased onto the target branch (usually main).

### Security
When developing applications, use following guidelines for information security considerations:
* Access to applications should be protected with security keys/tokens or usernames and passwords;
* All sessions are encrypted if possible;
* All application input is sanitised before being acted on (ie SQL statements, etc);
* Log messages, and especially client-facing ones, must be handled securely and must not leak credentials information (internal URLs, passwords, tokens).

- [x] I have considered if this change impacts information security and made sure those impacts are handled.

### Documentation
- [x] I have updated the changelog.
~- [ ] I have updated any documentation required for these changes.~

# Breaking Changes
- [x] I have considered if this is a breaking change and will communicate it with other team members by posting it on the Slack **breaking-changes** channel.

Non-breaking, but is likely to find where you omitted things or did them wrong when you start calling it.